### PR TITLE
Compilation Fixes: symbol conflict and g_clear_pointer casting

### DIFF
--- a/libwalbottle/wbl-schema.c
+++ b/libwalbottle/wbl-schema.c
@@ -532,7 +532,7 @@ wbl_validate_message_free (WblValidateMessage *self)
 	g_free (self->specification_section);
 	g_free (self->specification);
 	g_free (self->node_path);
-	g_clear_pointer (&self->node, (GDestroyNotify) json_node_free);
+	g_clear_pointer (&self->node, json_node_free);
 	g_free (self->message);
 
 	g_slice_free (WblValidateMessage, self);
@@ -1058,8 +1058,7 @@ wbl_schema_dispose (GObject *object)
 	}
 
 	g_clear_pointer (&priv->messages, g_ptr_array_unref);
-	g_clear_pointer (&priv->schema_instances_cache,
-	                 (GDestroyNotify) g_hash_table_unref);
+	g_clear_pointer (&priv->schema_instances_cache, g_hash_table_unref);
 
 	/* Chain up to the parent class */
 	G_OBJECT_CLASS (wbl_schema_parent_class)->dispose (object);
@@ -3053,8 +3052,7 @@ generate_all_items (WblSchema                       *self,
 	g_hash_table_unref (mutation_set);
 	g_hash_table_unref (instance_set);
 	g_ptr_array_unref (subschema_arrays);
-	g_clear_pointer (&additional_items_subschema,
-	                 (GDestroyNotify) json_object_unref);
+	g_clear_pointer (&additional_items_subschema, json_object_unref);
 	g_object_unref (builder);
 }
 
@@ -7215,8 +7213,7 @@ start_loading (WblSchema *self)
 	g_clear_pointer (&priv->messages, g_ptr_array_unref);
 
 	/* And clear any left-over generation caches. */
-	g_clear_pointer (&priv->schema_instances_cache,
-	                 (GDestroyNotify) g_hash_table_unref);
+	g_clear_pointer (&priv->schema_instances_cache, g_hash_table_unref);
 }
 
 static void
@@ -7263,8 +7260,7 @@ finish_loading (WblSchema *self, JsonNode *root, GError **error)
 	if (child_error != NULL) {
 		/* Clear out state. */
 		g_clear_pointer (&priv->schema, wbl_schema_node_unref);
-		g_clear_pointer (&priv->schema_instances_cache,
-		                 (GDestroyNotify) g_hash_table_unref);
+		g_clear_pointer (&priv->schema_instances_cache, g_hash_table_unref);
 
 		g_propagate_error (error, child_error);
 	}

--- a/utilities/json-schema-generate.c
+++ b/utilities/json-schema-generate.c
@@ -31,7 +31,7 @@
 /* Exit statuses. */
 typedef enum {
 	/* Success. */
-	EXIT_SUCCESS = 0,
+	EXIT_OK = 0,
 	/* Error parsing command line options. */
 	EXIT_INVALID_OPTIONS = 1,
 	/* JSON schema could not be parsed. */
@@ -105,7 +105,7 @@ int
 main (int argc, char *argv[])
 {
 	GOptionContext *context = NULL;  /* owned */
-	ExitStatus retval = EXIT_SUCCESS;
+	ExitStatus retval = EXIT_OK;
 	guint i;
 	GPtrArray/*<owned WblSchema>*/ *schemas = NULL;  /* owned */
 	WblGenerateInstanceFlags flags;

--- a/utilities/json-schema-validate.c
+++ b/utilities/json-schema-validate.c
@@ -30,7 +30,7 @@
 /* Exit statuses. */
 typedef enum {
 	/* Success. */
-	EXIT_SUCCESS = 0,
+	EXIT_OK = 0,
 	/* Error parsing command line options. */
 	EXIT_INVALID_OPTIONS = 1,
 	/* JSON schema could not be parsed. */
@@ -65,7 +65,7 @@ int
 main (int argc, char *argv[])
 {
 	GOptionContext *context = NULL;  /* owned */
-	ExitStatus retval = EXIT_SUCCESS;
+	ExitStatus retval = EXIT_OK;
 	guint i;
 	GPtrArray/*<owned WblSchema>*/ *schemas = NULL;  /* owned */
 	WblSchema *meta_schema = NULL;  /* owned */
@@ -141,7 +141,7 @@ main (int argc, char *argv[])
 				g_free (message);
 			}
 
-			if (retval == EXIT_SUCCESS) {
+			if (retval == EXIT_OK) {
 				retval = EXIT_INVALID_SCHEMA;
 			}
 			g_clear_error (&error);
@@ -221,7 +221,7 @@ main (int argc, char *argv[])
 				g_free (message);
 			}
 
-			if (retval == EXIT_SUCCESS) {
+			if (retval == EXIT_OK) {
 				retval = EXIT_SCHEMA_VALIDATION_FAILED;
 			}
 			g_clear_error (&error);

--- a/utilities/json-validate.c
+++ b/utilities/json-validate.c
@@ -29,7 +29,7 @@
 /* Exit statuses. */
 typedef enum {
 	/* Success. */
-	EXIT_SUCCESS = 0,
+	EXIT_OK = 0,
 	/* Error parsing command line options. */
 	EXIT_INVALID_OPTIONS = 1,
 	/* JSON file could not be parsed. */
@@ -66,7 +66,7 @@ int
 main (int argc, char *argv[])
 {
 	GOptionContext *context = NULL;  /* owned */
-	ExitStatus retval = EXIT_SUCCESS;
+	ExitStatus retval = EXIT_OK;
 	guint i, j;
 	GPtrArray/*<owned JsonParser>*/ *json_files = NULL;  /* owned */
 	GPtrArray/*<owned WblSchema>*/ *schemas = NULL;  /* owned */
@@ -131,7 +131,7 @@ main (int argc, char *argv[])
 				g_free (message);
 			}
 
-			if (retval == EXIT_SUCCESS) {
+			if (retval == EXIT_OK) {
 				retval = EXIT_INVALID_JSON;
 			}
 			g_clear_error (&error);
@@ -172,7 +172,7 @@ main (int argc, char *argv[])
 				g_free (message);
 			}
 
-			if (retval == EXIT_SUCCESS) {
+			if (retval == EXIT_OK) {
 				retval = EXIT_INVALID_SCHEMA;
 			}
 			g_clear_error (&error);
@@ -239,7 +239,7 @@ main (int argc, char *argv[])
 					g_free (message);
 				}
 
-				if (retval == EXIT_SUCCESS) {
+				if (retval == EXIT_OK) {
 					retval = EXIT_SCHEMA_VALIDATION_FAILED;
 				}
 				g_clear_error (&error);


### PR DESCRIPTION
`EXIT_SUCCESS` seems to conflict with something in `stdlib.h`, so change
it to `EXIT_OK`.

Casting free functions to `GDestroyNotify` in `g_clear_pointer ()`
throws an incompatible pointer error, so just pass those functions
without casting.

closes #2 

Signed-off-by: Andy Holmes <andrew.g.r.holmes@gmail.com>